### PR TITLE
fix(MissingFaultPath): exclude WaitDuration and WaitDate elements

### DIFF
--- a/src/main/rules/MissingFaultPath.ts
+++ b/src/main/rules/MissingFaultPath.ts
@@ -34,14 +34,28 @@ export class MissingFaultPath
       suppressionElement: "actionName",
     });
   }
+
+  private isValidSubtype(proxyNode: core.FlowNode): boolean {
+    if (!this.applicableElements.includes(proxyNode.subtype)) {
+      return false;
+    }
+
+    if (proxyNode.subtype === "waits") {
+      const elementSubtype: string = (proxyNode.element as Record<string, unknown>)?.["elementSubtype"] as string;
+      const excludedSubtypes: string[] = ["WaitDuration", "WaitDate"];
+      return !excludedSubtypes.includes(elementSubtype);
+    }
+
+    return true;
+  }
+
   public execute(flow: core.Flow): core.RuleResult {
     const compiler = new core.Compiler();
     const results: core.ResultDetails[] = [];
     const elementsWhereFaultPathIsApplicable = (
       flow.elements?.filter((node) => {
         const proxyNode = node as unknown as core.FlowNode;
-        const validSubtype = this.applicableElements.includes(proxyNode.subtype);
-        return validSubtype;
+        return this.isValidSubtype(proxyNode);
       }) as core.FlowNode[]
     ).map((e) => e.name);
 

--- a/tests/MissingFaultPath.test.ts
+++ b/tests/MissingFaultPath.test.ts
@@ -58,4 +58,31 @@ describe("MissingFaultPath", () => {
     const occurringResults = results[0].ruleResults.filter((rule) => rule.occurs);
     expect(occurringResults).toHaveLength(0);
   });
+
+  it("should not flag WaitDuration elements as missing fault path", async () => {
+    const { default: rawFile } = await import("./jsonfiles/MissingFaultPath_WaitDuration.json");
+    const parsedFile: ParsedFlow[] = rawFile as unknown as ParsedFlow[];
+    const missingFaultPathRule = new MissingFaultPath();
+    const flow: Flow = parsedFile.pop()?.flow as Flow;
+    const scanResults: RuleResult = missingFaultPathRule.execute(flow);
+    expect(scanResults.occurs).toBe(false);
+  });
+
+  it("should not flag WaitDate elements as missing fault path", async () => {
+    const { default: rawFile } = await import("./jsonfiles/MissingFaultPath_WaitDate.json");
+    const parsedFile: ParsedFlow[] = rawFile as unknown as ParsedFlow[];
+    const missingFaultPathRule = new MissingFaultPath();
+    const flow: Flow = parsedFile.pop()?.flow as Flow;
+    const scanResults: RuleResult = missingFaultPathRule.execute(flow);
+    expect(scanResults.occurs).toBe(false);
+  });
+
+  it("should flag Wait For Conditions elements as missing fault path", async () => {
+    const { default: rawFile } = await import("./jsonfiles/MissingFaultPath_WaitConditions.json");
+    const parsedFile: ParsedFlow[] = rawFile as unknown as ParsedFlow[];
+    const missingFaultPathRule = new MissingFaultPath();
+    const flow: Flow = parsedFile.pop()?.flow as Flow;
+    const scanResults: RuleResult = missingFaultPathRule.execute(flow);
+    expect(scanResults.occurs).toBe(true);
+  });
 });

--- a/tests/jsonfiles/MissingFaultPath_WaitConditions.json
+++ b/tests/jsonfiles/MissingFaultPath_WaitConditions.json
@@ -1,0 +1,106 @@
+[
+  {
+    "flow": {
+      "flowVariables": [],
+      "flowResources": [],
+      "flowMetadata": ["apiVersion", "processType", "label", "status"],
+      "flowNodes": ["waits", "start"],
+      "name": "Test_Flow_WaitConditions",
+      "xmldata": {
+        "@xmlns": "http://soap.sforce.com/2006/04/metadata",
+        "apiVersion": "62.0",
+        "label": "Test Flow Wait Conditions",
+        "processType": "AutoLaunchedFlow",
+        "waits": {
+          "name": "Wait_For_Conditions",
+          "label": "Wait For Conditions",
+          "locationX": "176",
+          "locationY": "287",
+          "waitEvents": {
+            "name": "myWaitEvent",
+            "conditionLogic": "and",
+            "conditions": {
+              "leftValueReference": "myVariable_current.Status",
+              "operator": "EqualTo",
+              "rightValue": { "stringValue": "Completed" }
+            }
+          }
+        },
+        "start": {
+          "locationX": "50",
+          "locationY": "0",
+          "connector": { "targetReference": "Wait_For_Conditions" },
+          "triggerType": "RecordAfterSave",
+          "object": "Account",
+          "recordTriggerType": "Create"
+        },
+        "status": "Draft"
+      },
+      "label": "Test Flow Wait Conditions",
+      "processType": "AutoLaunchedFlow",
+      "start": {
+        "locationX": "50",
+        "locationY": "0",
+        "connector": { "targetReference": "Wait_For_Conditions" },
+        "triggerType": "RecordAfterSave",
+        "object": "Account",
+        "recordTriggerType": "Create"
+      },
+      "status": "Draft",
+      "type": "AutoLaunchedFlow",
+      "elements": [
+        { "element": "62.0", "subtype": "apiVersion", "metaType": "metadata" },
+        { "element": "Test Flow Wait Conditions", "subtype": "label", "metaType": "metadata" },
+        { "element": "AutoLaunchedFlow", "subtype": "processType", "metaType": "metadata" },
+        {
+          "element": {
+            "name": "Wait_For_Conditions",
+            "label": "Wait For Conditions",
+            "locationX": "176",
+            "locationY": "287",
+            "waitEvents": {
+              "name": "myWaitEvent",
+              "conditionLogic": "and",
+              "conditions": {
+                "leftValueReference": "myVariable_current.Status",
+                "operator": "EqualTo",
+                "rightValue": { "stringValue": "Completed" }
+              }
+            }
+          },
+          "subtype": "waits",
+          "metaType": "node",
+          "connectors": [],
+          "name": "Wait_For_Conditions",
+          "locationX": "176",
+          "locationY": "287"
+        },
+        {
+          "element": {
+            "locationX": "50",
+            "locationY": "0",
+            "connector": { "targetReference": "Wait_For_Conditions" },
+            "triggerType": "RecordAfterSave",
+            "object": "Account",
+            "recordTriggerType": "Create"
+          },
+          "subtype": "start",
+          "metaType": "node",
+          "connectors": [
+            {
+              "element": { "targetReference": "Wait_For_Conditions" },
+              "processed": false,
+              "type": "connector",
+              "reference": "Wait_For_Conditions"
+            }
+          ],
+          "name": "flowstart",
+          "locationX": "50",
+          "locationY": "0"
+        },
+        { "element": "Draft", "subtype": "status", "metaType": "metadata" }
+      ],
+      "startReference": "Wait_For_Conditions"
+    }
+  }
+]

--- a/tests/jsonfiles/MissingFaultPath_WaitDate.json
+++ b/tests/jsonfiles/MissingFaultPath_WaitDate.json
@@ -1,0 +1,92 @@
+[
+  {
+    "flow": {
+      "flowVariables": [],
+      "flowResources": [],
+      "flowMetadata": ["apiVersion", "processType", "label", "status"],
+      "flowNodes": ["waits", "start"],
+      "name": "Test_Flow_WaitDate",
+      "xmldata": {
+        "@xmlns": "http://soap.sforce.com/2006/04/metadata",
+        "apiVersion": "62.0",
+        "label": "Test Flow WaitDate",
+        "processType": "AutoLaunchedFlow",
+        "waits": {
+          "name": "Wait_Until_Date",
+          "label": "Wait Until Date",
+          "locationX": "176",
+          "locationY": "287",
+          "elementSubtype": "WaitDate",
+          "dateTimeValue": "2025-12-31T00:00:00.000Z"
+        },
+        "start": {
+          "locationX": "50",
+          "locationY": "0",
+          "connector": { "targetReference": "Wait_Until_Date" },
+          "triggerType": "RecordAfterSave",
+          "object": "Account",
+          "recordTriggerType": "Create"
+        },
+        "status": "Draft"
+      },
+      "label": "Test Flow WaitDate",
+      "processType": "AutoLaunchedFlow",
+      "start": {
+        "locationX": "50",
+        "locationY": "0",
+        "connector": { "targetReference": "Wait_Until_Date" },
+        "triggerType": "RecordAfterSave",
+        "object": "Account",
+        "recordTriggerType": "Create"
+      },
+      "status": "Draft",
+      "type": "AutoLaunchedFlow",
+      "elements": [
+        { "element": "62.0", "subtype": "apiVersion", "metaType": "metadata" },
+        { "element": "Test Flow WaitDate", "subtype": "label", "metaType": "metadata" },
+        { "element": "AutoLaunchedFlow", "subtype": "processType", "metaType": "metadata" },
+        {
+          "element": {
+            "name": "Wait_Until_Date",
+            "label": "Wait Until Date",
+            "locationX": "176",
+            "locationY": "287",
+            "elementSubtype": "WaitDate",
+            "dateTimeValue": "2025-12-31T00:00:00.000Z"
+          },
+          "subtype": "waits",
+          "metaType": "node",
+          "connectors": [],
+          "name": "Wait_Until_Date",
+          "locationX": "176",
+          "locationY": "287"
+        },
+        {
+          "element": {
+            "locationX": "50",
+            "locationY": "0",
+            "connector": { "targetReference": "Wait_Until_Date" },
+            "triggerType": "RecordAfterSave",
+            "object": "Account",
+            "recordTriggerType": "Create"
+          },
+          "subtype": "start",
+          "metaType": "node",
+          "connectors": [
+            {
+              "element": { "targetReference": "Wait_Until_Date" },
+              "processed": false,
+              "type": "connector",
+              "reference": "Wait_Until_Date"
+            }
+          ],
+          "name": "flowstart",
+          "locationX": "50",
+          "locationY": "0"
+        },
+        { "element": "Draft", "subtype": "status", "metaType": "metadata" }
+      ],
+      "startReference": "Wait_Until_Date"
+    }
+  }
+]

--- a/tests/jsonfiles/MissingFaultPath_WaitDuration.json
+++ b/tests/jsonfiles/MissingFaultPath_WaitDuration.json
@@ -1,0 +1,94 @@
+[
+  {
+    "flow": {
+      "flowVariables": [],
+      "flowResources": [],
+      "flowMetadata": ["apiVersion", "processType", "label", "status"],
+      "flowNodes": ["waits", "start"],
+      "name": "Test_Flow_WaitDuration",
+      "xmldata": {
+        "@xmlns": "http://soap.sforce.com/2006/04/metadata",
+        "apiVersion": "62.0",
+        "label": "Test Flow WaitDuration",
+        "processType": "AutoLaunchedFlow",
+        "waits": {
+          "name": "Wait_5_Minutes",
+          "label": "Wait 5 Minutes",
+          "locationX": "176",
+          "locationY": "287",
+          "elementSubtype": "WaitDuration",
+          "timeOffset": 5,
+          "timeOffsetUnit": "Minutes"
+        },
+        "start": {
+          "locationX": "50",
+          "locationY": "0",
+          "connector": { "targetReference": "Wait_5_Minutes" },
+          "triggerType": "RecordAfterSave",
+          "object": "Account",
+          "recordTriggerType": "Create"
+        },
+        "status": "Draft"
+      },
+      "label": "Test Flow WaitDuration",
+      "processType": "AutoLaunchedFlow",
+      "start": {
+        "locationX": "50",
+        "locationY": "0",
+        "connector": { "targetReference": "Wait_5_Minutes" },
+        "triggerType": "RecordAfterSave",
+        "object": "Account",
+        "recordTriggerType": "Create"
+      },
+      "status": "Draft",
+      "type": "AutoLaunchedFlow",
+      "elements": [
+        { "element": "62.0", "subtype": "apiVersion", "metaType": "metadata" },
+        { "element": "Test Flow WaitDuration", "subtype": "label", "metaType": "metadata" },
+        { "element": "AutoLaunchedFlow", "subtype": "processType", "metaType": "metadata" },
+        {
+          "element": {
+            "name": "Wait_5_Minutes",
+            "label": "Wait 5 Minutes",
+            "locationX": "176",
+            "locationY": "287",
+            "elementSubtype": "WaitDuration",
+            "timeOffset": 5,
+            "timeOffsetUnit": "Minutes"
+          },
+          "subtype": "waits",
+          "metaType": "node",
+          "connectors": [],
+          "name": "Wait_5_Minutes",
+          "locationX": "176",
+          "locationY": "287"
+        },
+        {
+          "element": {
+            "locationX": "50",
+            "locationY": "0",
+            "connector": { "targetReference": "Wait_5_Minutes" },
+            "triggerType": "RecordAfterSave",
+            "object": "Account",
+            "recordTriggerType": "Create"
+          },
+          "subtype": "start",
+          "metaType": "node",
+          "connectors": [
+            {
+              "element": { "targetReference": "Wait_5_Minutes" },
+              "processed": false,
+              "type": "connector",
+              "reference": "Wait_5_Minutes"
+            }
+          ],
+          "name": "flowstart",
+          "locationX": "50",
+          "locationY": "0"
+        },
+        { "element": "Draft", "subtype": "status", "metaType": "metadata" }
+      ],
+      "startReference": "Wait_5_Minutes"
+    }
+  }
+]


### PR DESCRIPTION
`WaitDuration` and `WaitDate` elements cannot have fault paths in Salesforce, only Wait For Conditions supports them.

- Updated rule to filter out `WaitDuration` and `WaitDuration` wait subtypes to prevent false positives.

Closes #272